### PR TITLE
Remove parenthesis suffix for methods/functions

### DIFF
--- a/lib/Util/SuggestionNameFormatter.php
+++ b/lib/Util/SuggestionNameFormatter.php
@@ -25,7 +25,7 @@ class SuggestionNameFormatter
                 return $this->trimLeadingDollar ? mb_substr($name, 1) : $name;
             case Suggestion::TYPE_FUNCTION:
             case Suggestion::TYPE_METHOD:
-                return $name . '(';
+                return $name;
         }
 
         return $name;

--- a/tests/Unit/Util/SuggestionNameFormatterTest.php
+++ b/tests/Unit/Util/SuggestionNameFormatterTest.php
@@ -32,7 +32,7 @@ class SuggestionNameFormatterTest extends TestCase
     {
         return [
             [Suggestion::TYPE_VARIABLE, '$foo', 'foo'],
-            [Suggestion::TYPE_FUNCTION, 'foo', 'foo('],
+            [Suggestion::TYPE_FUNCTION, 'foo', 'foo'],
             [Suggestion::TYPE_FIELD, 'foo', 'foo'],
         ];
     }


### PR DESCRIPTION
This inteferes with signature help.

The `editor.action.triggerParameterHints` is [VS Code Specific](https://github.com/microsoft/vscode-languageserver-node/issues/471#issuecomment-482018104) apparently, and is not in the spec. So that doesn't seem to be an option.

Finally we should provide text edits, which may help here.

cc @przepompownia 